### PR TITLE
Adds requirements file, fix deprecation warning and threshold value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SalivaPRINT
 
-SalivaPRINT available commands can be checked anytime by using -h as argument. The following commands are currently implemented (version 0.1):
+SalivaPRINT available commands can be checked anytime by using -h as argument. The following commands are currently implemented (version 0.1.1):
 
 -v: Displays the program and required libraries version.
 

--- a/salivaprint/requirements.txt
+++ b/salivaprint/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+scipy
+configparser
+matplotlib
+sklearn

--- a/salivaprint/salivaprint.py
+++ b/salivaprint/salivaprint.py
@@ -14,7 +14,7 @@ import math
 VERSION = 0.1.1
 
 # NP print options
-np.set_printoptions(threshold=0)
+np.set_printoptions(threshold=0.5)
 np.set_printoptions(suppress=True)
 
 def read_all_data(file):

--- a/salivaprint/salivaprint.py
+++ b/salivaprint/salivaprint.py
@@ -2,14 +2,15 @@ import configparser
 import csv
 import sys
 import numpy as np
-from sklearn.neighbors import KNeighborsClassifier
-from sklearn.metrics import accuracy_score
 import pylab as plt
 import scipy as scp
 import matplotlib
 import joblib
-from sklearn import preprocessing
 import math
+
+from sklearn import preprocessing
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.metrics import accuracy_score
 
 VERSION = 0.1.1
 

--- a/salivaprint/salivaprint.py
+++ b/salivaprint/salivaprint.py
@@ -7,14 +7,14 @@ from sklearn.metrics import accuracy_score
 import pylab as plt
 import scipy as scp
 import matplotlib
-from sklearn.externals import joblib
+import joblib
 from sklearn import preprocessing
 import math
 
-VERSION = 0.1
+VERSION = 0.1.1
 
 # NP print options
-np.set_printoptions(threshold=np.nan)
+np.set_printoptions(threshold=0)
 np.set_printoptions(suppress=True)
 
 def read_all_data(file):


### PR DESCRIPTION
- Adds a python requirements file to make it easier to install the dependencies
- Fix the sklearn.externals.joblib deprecation warning
- Fix the threshold value by changing it to the default one (0.5)
- Changes the version to 0.1.1